### PR TITLE
Add many forms support

### DIFF
--- a/lib/create-data-object-config.js
+++ b/lib/create-data-object-config.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 
 Object.defineProperty(exports, "__esModule", {
   value: true
@@ -39,7 +39,7 @@ function value(_ref2) {
   var name = _ref2.name,
       value = _ref2.value;
 
-  return _defineProperty({}, "" + name, value);
+  return _defineProperty({}, '' + name, value);
 }
 
 /**
@@ -55,7 +55,7 @@ function valueStringify(_ref4) {
   value = value && value.toJS ? value.toJS() : value;
   // Stringify if it's defined
   value = value != null ? JSON.stringify(value) : value;
-  return _defineProperty({}, "" + name, value);
+  return _defineProperty({}, '' + name, value);
 }
 
 /**
@@ -69,7 +69,7 @@ function attr(_ref6) {
       children = _ref6.children;
 
   children = children.toJS ? children.toJS() : children;
-  return _defineProperty({}, "" + name, children.reduce(objectReducer, {}));
+  return _defineProperty({}, '' + name, children.reduce(objectReducer, {}));
 }
 
 /**
@@ -83,9 +83,28 @@ function many(_ref8) {
       children = _ref8.children;
 
   children = children.toJS ? children.toJS() : children;
-  return _defineProperty({}, "" + name, children.map(function (c) {
+  return _defineProperty({}, '' + name, children.map(function (c) {
     return c.reduce(objectReducer, {});
   }));
+}
+
+function childForm(_ref10) {
+  var _ref11;
+
+  var name = _ref10.name,
+      attributes = _ref10.attributes,
+      children = _ref10.children;
+
+  children = children.toJS ? children.toJS() : children;
+  return _ref11 = {}, _defineProperty(_ref11, 'name', name), _defineProperty(_ref11, 'data', children.reduce(objectReducer, {})), _ref11;
+}
+
+function manyChildForms(_ref12) {
+  var name = _ref12.name,
+      children = _ref12.children;
+
+  children = children.toJS ? children.toJS() : children;
+  return _defineProperty({}, '' + name, children);
 }
 
 /**
@@ -103,7 +122,9 @@ function createDataObjectConfig() {
     many: many,
     compoundField: passThrough,
     group: passThrough,
-    section: passThrough
+    section: passThrough,
+    childForm: childForm,
+    manyChildForms: manyChildForms
   };
 
   return definition;

--- a/lib/create-data-object-config.js
+++ b/lib/create-data-object-config.js
@@ -108,6 +108,20 @@ function manyChildForms(_ref12) {
 }
 
 /**
+ * Render an attr block
+ * @param  {String} options.name Block name
+ * @param  {Object} options.children Children of the block
+ * @return {Object} Object defined with a name/value key pair
+ */
+function formField(_ref14) {
+  var name = _ref14.name,
+      children = _ref14.children;
+
+  children = children.toJS ? children.toJS() : children;
+  return _defineProperty({}, '' + name, children.reduce(objectReducer, {}));
+}
+
+/**
  * Create data object config
  * @return {Object} An object referencing the render functions above for each
  * component type
@@ -124,7 +138,8 @@ function createDataObjectConfig() {
     group: passThrough,
     section: passThrough,
     childForm: childForm,
-    manyChildForms: manyChildForms
+    manyChildForms: manyChildForms,
+    formField: formField
   };
 
   return definition;

--- a/lib/create-data-object-config.js
+++ b/lib/create-data-object-config.js
@@ -1,4 +1,4 @@
-'use strict';
+"use strict";
 
 Object.defineProperty(exports, "__esModule", {
   value: true
@@ -39,7 +39,7 @@ function value(_ref2) {
   var name = _ref2.name,
       value = _ref2.value;
 
-  return _defineProperty({}, '' + name, value);
+  return _defineProperty({}, "" + name, value);
 }
 
 /**
@@ -55,7 +55,7 @@ function valueStringify(_ref4) {
   value = value && value.toJS ? value.toJS() : value;
   // Stringify if it's defined
   value = value != null ? JSON.stringify(value) : value;
-  return _defineProperty({}, '' + name, value);
+  return _defineProperty({}, "" + name, value);
 }
 
 /**
@@ -69,7 +69,7 @@ function attr(_ref6) {
       children = _ref6.children;
 
   children = children.toJS ? children.toJS() : children;
-  return _defineProperty({}, '' + name, children.reduce(objectReducer, {}));
+  return _defineProperty({}, "" + name, children.reduce(objectReducer, {}));
 }
 
 /**
@@ -83,7 +83,7 @@ function many(_ref8) {
       children = _ref8.children;
 
   children = children.toJS ? children.toJS() : children;
-  return _defineProperty({}, '' + name, children.map(function (c) {
+  return _defineProperty({}, "" + name, children.map(function (c) {
     return c.reduce(objectReducer, {});
   }));
 }
@@ -96,15 +96,15 @@ function childForm(_ref10) {
       children = _ref10.children;
 
   children = children.toJS ? children.toJS() : children;
-  return _ref11 = {}, _defineProperty(_ref11, 'name', name), _defineProperty(_ref11, 'data', children.reduce(objectReducer, {})), _ref11;
+  return _ref11 = {}, _defineProperty(_ref11, "name", name), _defineProperty(_ref11, "data", children.reduce(objectReducer, {})), _ref11;
 }
 
-function manyChildForms(_ref12) {
+function manyForms(_ref12) {
   var name = _ref12.name,
       children = _ref12.children;
 
   children = children.toJS ? children.toJS() : children;
-  return _defineProperty({}, '' + name, children);
+  return _defineProperty({}, "" + name, children);
 }
 
 /**
@@ -118,7 +118,7 @@ function formField(_ref14) {
       children = _ref14.children;
 
   children = children.toJS ? children.toJS() : children;
-  return _defineProperty({}, '' + name, children.reduce(objectReducer, {}));
+  return _defineProperty({}, "" + name, children.reduce(objectReducer, {}));
 }
 
 /**
@@ -138,7 +138,7 @@ function createDataObjectConfig() {
     group: passThrough,
     section: passThrough,
     childForm: childForm,
-    manyChildForms: manyChildForms,
+    manyForms: manyForms,
     formField: formField
   };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "formalist-data-object-renderer",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2281,7 +2281,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2302,12 +2303,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2322,17 +2325,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2449,7 +2455,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2461,6 +2468,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2475,6 +2483,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2482,12 +2491,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2506,6 +2517,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2586,7 +2598,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2598,6 +2611,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2683,7 +2697,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2719,6 +2734,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2738,6 +2754,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2781,12 +2798,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -2856,6 +2875,7 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-glob": "^2.0.0"
       }
@@ -3211,7 +3231,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
       "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-finite": {
       "version": "1.0.2",
@@ -3236,6 +3257,7 @@
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-extglob": "^1.0.0"
       }

--- a/src/create-data-object-config.js
+++ b/src/create-data-object-config.js
@@ -86,6 +86,19 @@ function manyChildForms ({name, children}) {
 }
 
 /**
+ * Render an attr block
+ * @param  {String} options.name Block name
+ * @param  {Object} options.children Children of the block
+ * @return {Object} Object defined with a name/value key pair
+ */
+function formField ({name, children}) {
+  children = (children.toJS) ? children.toJS() : children
+  return {
+    [`${name}`]: children.reduce(objectReducer, {}),
+  }
+}
+
+/**
  * Create data object config
  * @return {Object} An object referencing the render functions above for each
  * component type
@@ -103,6 +116,7 @@ export default function createDataObjectConfig () {
     section: passThrough,
     childForm: childForm,
     manyChildForms: manyChildForms,
+    formField: formField,
   }
 
   return definition

--- a/src/create-data-object-config.js
+++ b/src/create-data-object-config.js
@@ -4,8 +4,8 @@
  * @param  {Object} b
  * @return {Object} Merged combination of `a` and `b`
  */
-export function objectReducer (a, b) {
-  return Object.assign(a, b)
+export function objectReducer(a, b) {
+  return Object.assign(a, b);
 }
 
 /**
@@ -13,8 +13,8 @@ export function objectReducer (a, b) {
  * @param  {Mixed} options.children Children to render
  * @return {Object}
  */
-function passThrough ({children}) {
-  return children.reduce(objectReducer, {})
+function passThrough({ children }) {
+  return children.reduce(objectReducer, {});
 }
 
 /**
@@ -23,10 +23,10 @@ function passThrough ({children}) {
  * @param  {Mixed} options.value Component value
  * @return {Object} Object defined with a name/value key pair
  */
-function value ({name, value}) {
+function value({ name, value }) {
   return {
     [`${name}`]: value,
-  }
+  };
 }
 
 /**
@@ -35,13 +35,13 @@ function value ({name, value}) {
  * @param  {Mixed} options.value Component value
  * @return {Object} Object defined with a name/value key pair
  */
-function valueStringify ({name, value}) {
-  value = (value && value.toJS) ? value.toJS() : value
+function valueStringify({ name, value }) {
+  value = value && value.toJS ? value.toJS() : value;
   // Stringify if it's defined
-  value = (value != null) ? JSON.stringify(value) : value
+  value = value != null ? JSON.stringify(value) : value;
   return {
     [`${name}`]: value,
-  }
+  };
 }
 
 /**
@@ -50,11 +50,11 @@ function valueStringify ({name, value}) {
  * @param  {Object} options.children Children of the block
  * @return {Object} Object defined with a name/value key pair
  */
-function attr ({name, children}) {
-  children = (children.toJS) ? children.toJS() : children
+function attr({ name, children }) {
+  children = children.toJS ? children.toJS() : children;
   return {
     [`${name}`]: children.reduce(objectReducer, {}),
-  }
+  };
 }
 
 /**
@@ -63,26 +63,26 @@ function attr ({name, children}) {
  * @param  {Array} options.children Children of the block
  * @return {Object} Object defined with a name/value key pair
  */
-function many ({name, children}) {
-  children = (children.toJS) ? children.toJS() : children
+function many({ name, children }) {
+  children = children.toJS ? children.toJS() : children;
   return {
     [`${name}`]: children.map((c) => c.reduce(objectReducer, {})),
-  }
+  };
 }
 
-function childForm ({name, attributes, children}) {
-  children = (children.toJS) ? children.toJS() : children
+function childForm({ name, attributes, children }) {
+  children = children.toJS ? children.toJS() : children;
   return {
-    ['name']: name,
-    ['data']: children.reduce(objectReducer, {}),
-  }
+    ["name"]: name,
+    ["data"]: children.reduce(objectReducer, {}),
+  };
 }
 
-function manyChildForms ({name, children}) {
-  children = (children.toJS) ? children.toJS() : children
+function manyForms({ name, children }) {
+  children = children.toJS ? children.toJS() : children;
   return {
     [`${name}`]: children,
-  }
+  };
 }
 
 /**
@@ -91,11 +91,11 @@ function manyChildForms ({name, children}) {
  * @param  {Object} options.children Children of the block
  * @return {Object} Object defined with a name/value key pair
  */
-function formField ({name, children}) {
-  children = (children.toJS) ? children.toJS() : children
+function formField({ name, children }) {
+  children = children.toJS ? children.toJS() : children;
   return {
     [`${name}`]: children.reduce(objectReducer, {}),
-  }
+  };
 }
 
 /**
@@ -103,7 +103,7 @@ function formField ({name, children}) {
  * @return {Object} An object referencing the render functions above for each
  * component type
  */
-export default function createDataObjectConfig () {
+export default function createDataObjectConfig() {
   const definition = {
     fields: {
       default: value,
@@ -115,9 +115,9 @@ export default function createDataObjectConfig () {
     group: passThrough,
     section: passThrough,
     childForm: childForm,
-    manyChildForms: manyChildForms,
+    manyForms: manyForms,
     formField: formField,
-  }
+  };
 
-  return definition
+  return definition;
 }

--- a/src/create-data-object-config.js
+++ b/src/create-data-object-config.js
@@ -70,6 +70,21 @@ function many ({name, children}) {
   }
 }
 
+function childForm ({name, attributes, children}) {
+  children = (children.toJS) ? children.toJS() : children
+  return {
+    ['name']: name,
+    ['data']: children.reduce(objectReducer, {}),
+  }
+}
+
+function manyChildForms ({name, children}) {
+  children = (children.toJS) ? children.toJS() : children
+  return {
+    [`${name}`]: children,
+  }
+}
+
 /**
  * Create data object config
  * @return {Object} An object referencing the render functions above for each
@@ -86,6 +101,8 @@ export default function createDataObjectConfig () {
     compoundField: passThrough,
     group: passThrough,
     section: passThrough,
+    childForm: childForm,
+    manyChildForms: manyChildForms,
   }
 
   return definition


### PR DESCRIPTION
This adds support for ManyForms fields, the primary PR for which is here: team-formalist/formalist-rb#93

It adds support for rendering `manyForms`, `formField` and `childForm` components when forms are submitted.

Some formatting tweaks were made by prettier.